### PR TITLE
Add fetching and caching of config

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ $ export BINTRAY_KEY=key
 $ export BINTRY_REPO=repo_name
 ```
 
+## How to test the Sample app
+
+You must first define your API base url, App Id, and subscription key as either environment variables or as gradle properties (such as in your global `~/.gradle/gradle.properties` file).
+
+```
+REMOTE_CONFIG_APP_ID=your_app_id
+REMOTE_CONFIG_SUBSCRIPTION_KEY=your_subscription_key
+REMOTE_CONFIG_BASE_URL=https://www.example.com/
+```
+
 ## How to use it
 
 Currently we do not host any public APIs but you can create your own APIs and configure the SDK to use those.

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ buildscript {
   CONFIG.versions.android.sdk.min = 21
   CONFIG.versions.kotlin = '1.3.21'
   CONFIG.versions.android.plugin = '3.3.1'
+  CONFIG.versions.okhttp = '3.12.3'
 
   repositories {
     google()

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,10 @@ buildscript {
   }
 }
 
+plugins {
+  id 'io.gitlab.arturbosch.detekt' version '1.0.0-RC14'
+}
+
 allprojects { proj ->
   repositories {
     google()

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,3 +7,4 @@ scmUrl=https://github.com/rakutentech/android-remote-config.git
 
 android.enableJetifier=true
 android.useAndroidX=true
+android.databinding.enableV2=true

--- a/remote-config/build.gradle
+++ b/remote-config/build.gradle
@@ -57,3 +57,7 @@ jacoco {
 
 apply from: "../config/quality/checkstyle/android.gradle"
 apply from: "../config/quality/detekt/android.gradle"
+dependencies {
+  // Enable the KtLint rules
+  detektPlugins "io.gitlab.arturbosch.detekt:detekt-formatting:1.0.0-RC14"
+}

--- a/remote-config/build.gradle
+++ b/remote-config/build.gradle
@@ -18,18 +18,19 @@ android {
 
 dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$CONFIG.versions.kotlin"
-  implementation 'com.squareup.retrofit2:retrofit:2.5.0'
+  implementation "com.squareup.okhttp3:okhttp:$CONFIG.versions.okhttp"
   implementation 'androidx.annotation:annotation:1.0.1'
   implementation "com.rakuten.tech.mobile:manifest-config-annotations:0.1.0"
   kapt "com.rakuten.tech.mobile:manifest-config-processor:0.1.0"
-  implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.10.0"
+  implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.11.0"
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.1.1"
 
   testImplementation 'junit:junit:4.12'
   testImplementation 'org.robolectric:robolectric:3.8'
   testImplementation "org.amshove.kluent:kluent-android:1.48"
   testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.1.0"
-  testImplementation "com.squareup.okhttp3:mockwebserver:3.14.0"
+  testImplementation "org.mockito:mockito-inline:2.28.2"
+  testImplementation "com.squareup.okhttp3:mockwebserver:$CONFIG.versions.okhttp"
   testImplementation 'org.awaitility:awaitility-kotlin:3.1.6'
 }
 

--- a/remote-config/src/main/AndroidManifest.xml
+++ b/remote-config/src/main/AndroidManifest.xml
@@ -5,5 +5,11 @@
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
-  <application />
+  <application>
+    <provider
+      android:name="com.rakuten.tech.mobile.remoteconfig.RemoteConfigInitProvider"
+      android:authorities="${applicationId}.RemoteConfigInitProvider"
+      android:exported="false"
+      android:initOrder="99" />
+  </application>
 </manifest>

--- a/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/ConfigCache.kt
+++ b/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/ConfigCache.kt
@@ -9,7 +9,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import java.io.File
 
-@Suppress("TooGenericExceptionCaught", "UndocumentedPublicFunction")
+@Suppress("TooGenericExceptionCaught")
 internal class ConfigCache @VisibleForTesting constructor(
     fetcher: ConfigFetcher,
     file: File

--- a/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/ConfigCache.kt
+++ b/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/ConfigCache.kt
@@ -1,0 +1,55 @@
+package com.rakuten.tech.mobile.remoteconfig
+
+import android.content.Context
+import android.util.Log
+import androidx.annotation.VisibleForTesting
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import java.io.File
+
+@Suppress("TooGenericExceptionCaught", "UndocumentedPublicFunction")
+internal class ConfigCache @VisibleForTesting constructor(
+    fetcher: ConfigFetcher,
+    file: File
+) {
+
+    constructor(context: Context, fetcher: ConfigFetcher) : this(
+        fetcher,
+        File(
+            context.filesDir,
+            "com.rakuten.tech.mobile.remoteconfig.configcache.json"
+        )
+    )
+
+    private val json = if (file.exists()) file.readText() else ""
+    private val config = if (json.isNotBlank())
+        Config.fromJsonString(json)
+    else Config(hashMapOf())
+
+    init {
+        GlobalScope.launch {
+            try {
+                val fetchedConfig = fetcher.fetch()
+                val configJson = Config(fetchedConfig).toJsonString()
+
+                file.writeText(configJson)
+            } catch (error: Exception) {
+                Log.e("RemoteConfig", "Error while fetching config from server", error)
+            }
+        }
+    }
+
+    operator fun get(key: String) = config.values[key]
+}
+
+@Serializable
+private data class Config(val values: Map<String, String>) {
+
+    fun toJsonString() = Json.stringify(serializer(), this)
+
+    companion object {
+        fun fromJsonString(body: String) = Json.nonstrict.parse(serializer(), body)
+    }
+}

--- a/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/ConfigFetcher.kt
+++ b/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/ConfigFetcher.kt
@@ -1,0 +1,60 @@
+package com.rakuten.tech.mobile.remoteconfig
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okhttp3.HttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.IOException
+import java.lang.IllegalArgumentException
+
+@Suppress("UndocumentedPublicFunction")
+internal class ConfigFetcher(
+    baseUrl: String,
+    appId: String,
+    private val subscriptionKey: String
+) {
+
+    private val client = OkHttpClient()
+    private val requestUrl = try {
+        HttpUrl.get(baseUrl)
+            .newBuilder()
+            .addPathSegments("app/$appId/config")
+            .build()
+    } catch (exception: IllegalArgumentException) {
+        throw InvalidRemoteConfigBaseUrlException(exception)
+    }
+
+    fun fetch(): Map<String, String> {
+        val response = client.newCall(buildFetchRequest())
+            .execute()
+
+        if (!response.isSuccessful)
+            throw IOException("Unexpected response when fetching remote config: $response")
+
+        val body = response.body()!!.string() // Body is never null if request is successful
+
+        return ConfigResponse.fromJsonString(body).body
+    }
+
+    private fun buildFetchRequest() = Request.Builder()
+            .url(requestUrl)
+            .addHeader("apiKey", "ras-$subscriptionKey")
+            .build()
+}
+
+@Serializable
+private data class ConfigResponse(val body: Map<String, String>) {
+
+    companion object {
+        fun fromJsonString(body: String) = Json.nonstrict.parse(serializer(), body)
+    }
+}
+
+/**
+ * Exception thrown when the value set in `AndroidManifest.xml` for
+ * `com.rakuten.tech.mobile.remoteconfig.BaseUrl` is not a valid URL.
+ */
+class InvalidRemoteConfigBaseUrlException(
+    exception: IllegalArgumentException
+) : IllegalArgumentException("An invalid URL was provided for the Remote Config base url.", exception)

--- a/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/ConfigFetcher.kt
+++ b/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/ConfigFetcher.kt
@@ -8,7 +8,6 @@ import okhttp3.Request
 import java.io.IOException
 import java.lang.IllegalArgumentException
 
-@Suppress("UndocumentedPublicFunction")
 internal class ConfigFetcher(
     baseUrl: String,
     appId: String,

--- a/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/RealRemoteConfig.kt
+++ b/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/RealRemoteConfig.kt
@@ -1,5 +1,3 @@
 package com.rakuten.tech.mobile.remoteconfig
 
-class RealRemoteConfig {
-    fun test() = true
-}
+internal class RealRemoteConfig(): RemoteConfig()

--- a/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/RealRemoteConfig.kt
+++ b/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/RealRemoteConfig.kt
@@ -1,3 +1,5 @@
 package com.rakuten.tech.mobile.remoteconfig
 
-internal class RealRemoteConfig(): RemoteConfig()
+internal class RealRemoteConfig(
+    private val cache: ConfigCache
+) : RemoteConfig()

--- a/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/RealRemoteConfig.kt
+++ b/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/RealRemoteConfig.kt
@@ -2,4 +2,7 @@ package com.rakuten.tech.mobile.remoteconfig
 
 internal class RealRemoteConfig(
     private val cache: ConfigCache
-) : RemoteConfig()
+) : RemoteConfig() {
+
+    override fun getString(key: String, fallback: String) = cache[key] ?: fallback
+}

--- a/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/RemoteConfig.kt
+++ b/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/RemoteConfig.kt
@@ -18,13 +18,10 @@ abstract class RemoteConfig internal constructor() {
         @JvmStatic
         fun instance(): RemoteConfig = instance
 
-        internal fun init() {
-            instance = RealRemoteConfig()
+        internal fun init(cache: ConfigCache) {
+            instance = RealRemoteConfig(cache)
         }
-
     }
 }
 
-internal class NotInitialzedRemoteConfig: RemoteConfig() {
-
-}
+internal class NotInitialzedRemoteConfig : RemoteConfig()

--- a/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/RemoteConfig.kt
+++ b/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/RemoteConfig.kt
@@ -1,2 +1,30 @@
 package com.rakuten.tech.mobile.remoteconfig
 
+/**
+ * Main entry point for the Remote Config SDK.
+ * Should be accessed via [RemoteConfig.instance].
+ */
+@Suppress("UnnecessaryAbstractClass")
+abstract class RemoteConfig internal constructor() {
+
+    companion object {
+        private var instance: RemoteConfig = NotInitialzedRemoteConfig()
+
+        /**
+         * Instance of [RemoteConfig].
+         *
+         * @return [RemoteConfig] instance
+         */
+        @JvmStatic
+        fun instance(): RemoteConfig = instance
+
+        internal fun init() {
+            instance = RealRemoteConfig()
+        }
+
+    }
+}
+
+internal class NotInitialzedRemoteConfig: RemoteConfig() {
+
+}

--- a/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/RemoteConfig.kt
+++ b/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/RemoteConfig.kt
@@ -7,6 +7,16 @@ package com.rakuten.tech.mobile.remoteconfig
 @Suppress("UnnecessaryAbstractClass")
 abstract class RemoteConfig internal constructor() {
 
+    /**
+     * Get a string from the Cached config.
+     * If the key does not exist, [fallback] will be returned.
+     *
+     * @param key returns value for this key in the config
+     * @param fallback returned when the key does not exist
+     * @return String value for the specified key
+     */
+    abstract fun getString(key: String, fallback: String): String
+
     companion object {
         private var instance: RemoteConfig = NotInitialzedRemoteConfig()
 
@@ -24,4 +34,7 @@ abstract class RemoteConfig internal constructor() {
     }
 }
 
-internal class NotInitialzedRemoteConfig : RemoteConfig()
+internal class NotInitialzedRemoteConfig : RemoteConfig() {
+
+    override fun getString(key: String, fallback: String) = fallback
+}

--- a/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/RemoteConfigInitProvider.kt
+++ b/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/RemoteConfigInitProvider.kt
@@ -1,0 +1,69 @@
+package com.rakuten.tech.mobile.remoteconfig
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.net.Uri
+import com.rakuten.tech.mobile.manifestconfig.annotations.ManifestConfig
+import com.rakuten.tech.mobile.manifestconfig.annotations.MetaData
+
+/**
+ * Fake ContentProvider that initializes the Remote Config SDK.
+ *
+ * @suppress
+**/
+@Suppress("UndocumentedPublicClass")
+class RemoteConfigInitProvider : ContentProvider() {
+
+    @ManifestConfig
+    interface App {
+
+        /**
+         * Base Url for the Remote Config API.
+         **/
+        @MetaData(key = "com.rakuten.tech.mobile.remoteconfig.BaseUrl")
+        fun baseUrl(): String
+
+        /**
+         * App Id assigned to this App.
+         **/
+        @MetaData(key = "com.rakuten.tech.mobile.relay.AppId")
+        fun appId(): String
+
+        /**
+         * Subscription Key for the Remote Config API.
+         **/
+        @MetaData(key = "com.rakuten.tech.mobile.relay.SubscriptionKey")
+        fun subscriptionKey(): String
+    }
+
+    override fun onCreate(): Boolean {
+        val context = context ?: return false
+
+        RemoteConfig.init()
+
+        return true
+    }
+
+    override fun query(
+        uri: Uri,
+        projection: Array<String>?,
+        selection: String?,
+        selectionArgs: Array<String>?,
+        sortOrder: String?
+    ): Cursor? = null
+
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<String>?
+    ): Int = 0
+
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<String>?): Int = 0
+
+    override fun getType(uri: Uri): String? = null
+
+    override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+
+}

--- a/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/RemoteConfigInitProvider.kt
+++ b/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/RemoteConfigInitProvider.kt
@@ -40,7 +40,16 @@ class RemoteConfigInitProvider : ContentProvider() {
     override fun onCreate(): Boolean {
         val context = context ?: return false
 
-        RemoteConfig.init()
+        val manifestConfig = AppManifestConfig(context)
+
+        val fetcher = ConfigFetcher(
+            manifestConfig.baseUrl(),
+            manifestConfig.appId(),
+            manifestConfig.subscriptionKey()
+        )
+        val cache = ConfigCache(context, fetcher)
+
+        RemoteConfig.init(cache)
 
         return true
     }
@@ -65,5 +74,4 @@ class RemoteConfigInitProvider : ContentProvider() {
     override fun getType(uri: Uri): String? = null
 
     override fun insert(uri: Uri, values: ContentValues?): Uri? = null
-
 }

--- a/remote-config/src/test/kotlin/com/rakuten/tech/mobile/remoteconfig/ConfigCacheSpec.kt
+++ b/remote-config/src/test/kotlin/com/rakuten/tech/mobile/remoteconfig/ConfigCacheSpec.kt
@@ -1,0 +1,86 @@
+package com.rakuten.tech.mobile.remoteconfig
+
+import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.mock
+import org.amshove.kluent.*
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.until
+import org.junit.Test
+import org.robolectric.RuntimeEnvironment
+import java.io.File
+import java.io.IOException
+
+class ConfigCacheSpec : RobolectricBaseSpec() {
+
+    private val context = RuntimeEnvironment.application.applicationContext
+    private val stubFetcher: ConfigFetcher = mock()
+
+    @Test
+    fun `should be empty by default`() {
+        val cache = ConfigCache(context, stubFetcher)
+
+        cache["foo"] shouldBe null
+    }
+
+    @Test
+    fun `should apply the fetched config the next time App is launched`() {
+        `create cache with fetched config`(
+            configValues = hashMapOf("foo" to "bar")
+        )
+
+        val cache = `create cache with fetched config`()
+
+        cache["foo"] shouldEqual "bar"
+    }
+
+    @Test
+    fun `should not apply the fetched config while the App is running`() {
+        `create cache with fetched config`(
+            configValues = hashMapOf("foo" to "bar")
+        )
+
+        val cache = `create cache with fetched config`(
+            configValues = hashMapOf("foo" to "new_bar")
+        )
+
+        cache["foo"] shouldNotEqual "new_bar"
+    }
+
+    @Test
+    fun `should use the cached config when fetching fails`() {
+        val fileName = "cache.json"
+        `create cache with fetched config`(
+            fileName = fileName,
+            configValues = hashMapOf("foo" to "bar")
+        )
+
+        var exceptionThrown = false
+        When calling stubFetcher.fetch() doAnswer {
+            exceptionThrown = true
+            throw IOException("Failed.")
+        }
+
+        ConfigCache(stubFetcher, createFile(fileName))
+        await until { exceptionThrown }
+
+        val cache = ConfigCache(stubFetcher, createFile(fileName))
+
+        cache["foo"] shouldEqual "bar"
+    }
+
+    private fun `create cache with fetched config`(
+        configValues: Map<String, String> = hashMapOf("testKey" to "test_value"),
+        fileName: String = "cache.json"
+    ): ConfigCache {
+        val file = File(context.filesDir, fileName)
+        When calling stubFetcher.fetch() itReturns configValues
+
+        val cache = ConfigCache(stubFetcher, createFile(fileName))
+
+        await until { file.exists() && file.readText().isNotBlank() }
+
+        return cache
+    }
+
+    private fun createFile(name: String) = File(context.filesDir, name)
+}

--- a/remote-config/src/test/kotlin/com/rakuten/tech/mobile/remoteconfig/ConfigFetcherSpec.kt
+++ b/remote-config/src/test/kotlin/com/rakuten/tech/mobile/remoteconfig/ConfigFetcherSpec.kt
@@ -1,0 +1,164 @@
+package com.rakuten.tech.mobile.remoteconfig
+
+import junit.framework.TestCase
+import kotlinx.serialization.internal.StringSerializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.map
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.amshove.kluent.shouldContain
+import org.amshove.kluent.shouldEndWith
+import org.amshove.kluent.shouldEqual
+import org.amshove.kluent.shouldStartWith
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.io.IOException
+import java.util.logging.Level
+import java.util.logging.LogManager
+
+class ConfigFetcherSpec {
+
+    private val server = MockWebServer()
+    private lateinit var baseUrl: String
+
+    init {
+        LogManager.getLogManager()
+            .getLogger(MockWebServer::class.java.name).level = Level.OFF
+    }
+
+    @Before
+    fun setup() {
+        server.start()
+        baseUrl = server.url("config").toString()
+    }
+
+    @After
+    fun teardown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun `should fetch the config`() {
+        enqueueResponseValues(hashMapOf("foo" to "bar"))
+
+        val fetcher = createFetcher()
+
+        fetcher.fetch()["foo"] shouldEqual "bar"
+    }
+
+    @Test
+    fun `should fetch the config from the provided url`() {
+        enqueueResponseValues()
+
+        val fetcher = createFetcher(url = baseUrl)
+
+        fetcher.fetch()
+
+        server.takeRequest().requestUrl.toString() shouldStartWith baseUrl
+    }
+
+    @Test
+    fun `should fetch the config for the provided App Id`() {
+        enqueueResponseValues()
+
+        val fetcher = createFetcher(appId = "test-app-id")
+
+        fetcher.fetch()
+
+        server.takeRequest().path shouldContain "/app/test-app-id"
+    }
+
+    @Test
+    fun `should fetch the config from the 'config' endpoint`() {
+        enqueueResponseValues()
+
+        val fetcher = createFetcher()
+
+        fetcher.fetch()
+
+        server.takeRequest().path shouldEndWith "/config"
+    }
+
+    @Test
+    fun `should fetch the config using the provided Subscription Key prepended with 'ras-'`() {
+        enqueueResponseValues()
+
+        val fetcher = createFetcher(subscriptionKey = "test_subscription_key")
+
+        fetcher.fetch()
+
+        server.takeRequest().headers["apiKey"] shouldEqual "ras-test_subscription_key"
+    }
+
+    @Test(expected = Exception::class)
+    fun `should throw when an invalid base url is provided`() {
+        enqueueResponseValues()
+
+        createFetcher(url = "invalid url")
+    }
+
+    @Test(expected = IOException::class)
+    fun `should throw when the request is unsuccessful`() {
+        server.enqueue(
+            MockResponse().setResponseCode(400)
+        )
+
+        val fetcher = createFetcher()
+
+        fetcher.fetch()
+    }
+
+    @Test(expected = Exception::class)
+    fun `should throw when the 'body' key is missing in response`() {
+        server.enqueue(
+            MockResponse().setBody("""{"randomKey":"random_value"}""")
+        )
+
+        val fetcher = createFetcher()
+
+        fetcher.fetch()
+    }
+
+    @Test
+    @Suppress("TooGenericExceptionCaught")
+    fun `should not throw when there are extra keys in the response`() {
+        server.enqueue(
+            MockResponse().setBody("""
+                {
+                    "body": {},
+                    "randomKey": "random_value"
+                }
+            """.trimIndent())
+        )
+
+        val fetcher = createFetcher()
+
+        try {
+            fetcher.fetch()
+        } catch (e: Exception) {
+            TestCase.fail("Should not throw an exception.")
+            throw e
+        }
+    }
+
+    private fun enqueueResponseValues(
+        values: Map<String, String> = hashMapOf("foo" to "bar")
+    ) {
+        server.enqueue(
+            MockResponse().setBody("""
+                {
+                    "body": ${Json.nonstrict.stringify(
+                        (StringSerializer to StringSerializer).map, values
+                    )}
+                }
+            """.trimIndent())
+        )
+    }
+
+    private fun createFetcher(
+        url: String = baseUrl,
+        appId: String = "test_app_id",
+        subscriptionKey: String = "test_subscription_key"
+    ) = ConfigFetcher(url, appId, subscriptionKey)
+}

--- a/remote-config/src/test/kotlin/com/rakuten/tech/mobile/remoteconfig/RealRemoteConfigSpec.kt
+++ b/remote-config/src/test/kotlin/com/rakuten/tech/mobile/remoteconfig/RealRemoteConfigSpec.kt
@@ -1,11 +1,29 @@
 package com.rakuten.tech.mobile.remoteconfig
 
+import com.nhaarman.mockitokotlin2.mock
+import org.amshove.kluent.When
+import org.amshove.kluent.calling
+import org.amshove.kluent.itReturns
+import org.amshove.kluent.shouldEqual
 import org.junit.Test
 
 class RealRemoteConfigSpec {
 
+    private val stubCache: ConfigCache = mock()
+
     @Test
-    fun `should be true`() {
-        assert(RealRemoteConfig().test())
+    fun `should get string value for key`() {
+        When calling stubCache["test_key"] itReturns "test_value"
+
+        val remoteConfig = RealRemoteConfig(stubCache)
+
+        remoteConfig.getString("test_key", "fallback_value") shouldEqual "test_value"
+    }
+
+    @Test
+    fun `should return the fallback value for key that's not in cache`() {
+        val remoteConfig = RealRemoteConfig(stubCache)
+
+        remoteConfig.getString("random_key", "fallback_value") shouldEqual "fallback_value"
     }
 }

--- a/remote-config/src/test/kotlin/com/rakuten/tech/mobile/remoteconfig/RemoteConfigSpec.kt
+++ b/remote-config/src/test/kotlin/com/rakuten/tech/mobile/remoteconfig/RemoteConfigSpec.kt
@@ -1,0 +1,22 @@
+package com.rakuten.tech.mobile.remoteconfig
+
+import com.nhaarman.mockitokotlin2.mock
+import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldEqual
+import org.junit.Test
+
+class RemoteConfigSpec {
+
+    @Test
+    fun `should initialize instance with RealRemoteConfig`() {
+        RemoteConfig.init(mock())
+
+        RemoteConfig.instance() shouldBeInstanceOf RealRemoteConfig::class
+    }
+
+    @Test
+    fun `should return fallback string when not initialized`() {
+        RemoteConfig.instance()
+            .getString("test_key", "fallback_value") shouldEqual "fallback_value"
+    }
+}

--- a/remote-config/src/test/kotlin/com/rakuten/tech/mobile/remoteconfig/RobolectricBaseSpec.kt
+++ b/remote-config/src/test/kotlin/com/rakuten/tech/mobile/remoteconfig/RobolectricBaseSpec.kt
@@ -1,2 +1,11 @@
 package com.rakuten.tech.mobile.remoteconfig
 
+import org.junit.Ignore
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [27])
+@Ignore
+open class RobolectricBaseSpec

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -3,14 +3,28 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
+  def property = { key ->
+    return System.getenv(key) ?: (project.hasProperty(key) ? project."$key" : null)
+  }
+
   defaultConfig {
     applicationId "com.rakuten.tech.mobile.remoteconfig.sample"
     versionCode 1
     versionName "1.0"
+
+    manifestPlaceholders = [
+            appId: property("REMOTE_CONFIG_APP_ID") ?: "",
+            subscriptionKey: property("REMOTE_CONFIG_SUBSCRIPTION_KEY") ?: "",
+            baseUrl: property("REMOTE_CONFIG_BASE_URL") ?: "https://www.example.com/"
+    ]
   }
 
   sourceSets.each {
     it.java.srcDirs += "src/$it.name/kotlin"
+  }
+
+  dataBinding {
+    enabled = true
   }
 }
 

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -13,6 +13,18 @@
     android:networkSecurityConfig="@xml/network_security_config"
     tools:ignore="GoogleAppIndexingWarning">
 
+    <meta-data
+      android:name="com.rakuten.tech.mobile.remoteconfig.BaseUrl"
+      android:value="${baseUrl}" />
+
+    <meta-data
+      android:name="com.rakuten.tech.mobile.relay.AppId"
+      android:value="${appId}" />
+
+    <meta-data
+      android:name="com.rakuten.tech.mobile.relay.SubscriptionKey"
+      android:value="${subscriptionKey}" />
+
     <activity android:name=".MainActivity">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>

--- a/sample/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/sample/MainActivity.kt
+++ b/sample/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/sample/MainActivity.kt
@@ -1,12 +1,38 @@
 package com.rakuten.tech.mobile.remoteconfig.sample
 
 import android.os.Bundle
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import androidx.databinding.DataBindingUtil
+import com.rakuten.tech.mobile.remoteconfig.RemoteConfig
+import com.rakuten.tech.mobile.remoteconfig.sample.databinding.ActivityMainBinding
 
 class MainActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityMainBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        binding = DataBindingUtil.setContentView(this, R.layout.activity_main)
+        binding.activity = this
+    }
+
+    fun onGetStringClick() {
+        val key = binding.key.text.toString()
+        val fallback = binding.fallback.text.toString()
+
+        val value = RemoteConfig.instance().getString(key, fallback)
+
+        showToast("$key = $value")
+    }
+
+    private fun showToast(message: String) {
+        Toast.makeText(
+            this,
+            message,
+            Toast.LENGTH_SHORT
+        ).show()
     }
 }

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -1,10 +1,42 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
+<layout
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
-  android:layout_width="match_parent"
-  android:layout_height="match_parent"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
   tools:ignore="HardcodedText"
   tools:context=".MainActivity">
+  <data>
+    <variable
+      name="activity"
+      type="com.rakuten.tech.mobile.remoteconfig.sample.MainActivity"/>
+  </data>
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+  <androidx.constraintlayout.widget.ConstraintLayout
+    android:layout_margin="20dp"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <EditText
+      android:id="@+id/key"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:hint="Key"/>
+    <EditText
+      android:id="@+id/fallback"
+      app:layout_constraintTop_toBottomOf="@+id/key"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:hint="Fallback Value"/>
+    <Button
+      android:id="@+id/stringButton"
+      app:layout_constraintTop_toBottomOf="@+id/fallback"
+      android:textStyle="bold"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:onClick="@{() -> activity.onGetStringClick()}"
+      android:text="Get String"/>
+
+  </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>


### PR DESCRIPTION
# Description
This adds `ConfigFetcher` and `ConfigCache` classes and also auto-initializes the SDK to fetch the config at startup. I have also added the `getString` public api so that it can be tested in the sample app.

## Links
SDKCF-1089

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors