### PR TITLE
feat: Add Poller to fetch config at a set interval

### DIFF
--- a/remote-config/build.gradle
+++ b/remote-config/build.gradle
@@ -31,7 +31,7 @@ dependencies {
   testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.1.0"
   testImplementation "org.mockito:mockito-inline:2.28.2"
   testImplementation "com.squareup.okhttp3:mockwebserver:$CONFIG.versions.okhttp"
-  testImplementation 'org.awaitility:awaitility-kotlin:3.1.6'
+  testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.0-M1'
 }
 
 apply from: '../gradle/documentation.gradle'

--- a/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/AsyncPoller.kt
+++ b/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/AsyncPoller.kt
@@ -1,0 +1,28 @@
+package com.rakuten.tech.mobile.remoteconfig
+
+import androidx.annotation.VisibleForTesting
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import java.util.concurrent.TimeUnit
+
+internal class AsyncPoller @VisibleForTesting constructor(
+    delayInMinutes: Int,
+    private val scope: CoroutineScope
+) {
+
+    constructor(delayInMinutes: Int) : this(delayInMinutes, GlobalScope)
+
+    private val delayInMilliseconds = TimeUnit.MINUTES.toMillis(delayInMinutes.toLong())
+
+    fun start(method: () -> Any) {
+        scope.launch {
+            repeat(Int.MAX_VALUE) {
+                method.invoke()
+
+                delay(delayInMilliseconds)
+            }
+        }
+    }
+}

--- a/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/ConfigFetcher.kt
+++ b/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/ConfigFetcher.kt
@@ -28,8 +28,9 @@ internal class ConfigFetcher(
         val response = client.newCall(buildFetchRequest())
             .execute()
 
-        if (!response.isSuccessful)
+        if (!response.isSuccessful) {
             throw IOException("Unexpected response when fetching remote config: $response")
+        }
 
         val body = response.body()!!.string() // Body is never null if request is successful
 

--- a/remote-config/src/test/kotlin/com/rakuten/tech/mobile/remoteconfig/AsyncPollerSpec.kt
+++ b/remote-config/src/test/kotlin/com/rakuten/tech/mobile/remoteconfig/AsyncPollerSpec.kt
@@ -1,0 +1,33 @@
+package com.rakuten.tech.mobile.remoteconfig
+
+import kotlinx.coroutines.test.TestCoroutineScope
+import org.amshove.kluent.shouldEqual
+import org.junit.Test
+import java.util.concurrent.TimeUnit
+
+class AsyncPollerSpec {
+
+    private val testScope = TestCoroutineScope()
+
+    @Test
+    fun `should invoke the provided function`() {
+        var numberOfInvocations = 0
+        val poller = AsyncPoller(1, testScope)
+
+        poller.start { numberOfInvocations++ }
+
+        numberOfInvocations shouldEqual 1
+    }
+
+    @Test
+    fun `should poll at the specified interval`() {
+        var numberOfInvocations = 0
+        val poller = AsyncPoller(1, testScope)
+
+        poller.start { numberOfInvocations++ }
+
+        testScope.advanceTimeBy(TimeUnit.MINUTES.toMillis(5))
+
+        numberOfInvocations shouldEqual 6
+    }
+}


### PR DESCRIPTION
# Description
Add Poller to fetch config every 60 minutes. Newly fetched config will be applied at the next App launch.

## Links
SDKCF-1090

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors