### PR TITLE
Add Caching for OkHttp

### DIFF
--- a/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/ConfigFetcher.kt
+++ b/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/ConfigFetcher.kt
@@ -2,19 +2,24 @@ package com.rakuten.tech.mobile.remoteconfig
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import okhttp3.Cache
 import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import java.io.File
 import java.io.IOException
 import java.lang.IllegalArgumentException
 
 internal class ConfigFetcher(
     baseUrl: String,
     appId: String,
-    private val subscriptionKey: String
+    private val subscriptionKey: String,
+    cacheDirectory: File
 ) {
 
-    private val client = OkHttpClient()
+    private val client = OkHttpClient.Builder()
+        .cache(Cache(cacheDirectory, CACHE_SIZE))
+        .build()
     private val requestUrl = try {
         HttpUrl.get(baseUrl)
             .newBuilder()
@@ -41,6 +46,10 @@ internal class ConfigFetcher(
             .url(requestUrl)
             .addHeader("apiKey", "ras-$subscriptionKey")
             .build()
+
+    companion object {
+        private const val CACHE_SIZE = 1024 * 1024 * 2L
+    }
 }
 
 @Serializable

--- a/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/RemoteConfigInitProvider.kt
+++ b/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/RemoteConfigInitProvider.kt
@@ -43,9 +43,10 @@ class RemoteConfigInitProvider : ContentProvider() {
         val manifestConfig = AppManifestConfig(context)
 
         val fetcher = ConfigFetcher(
-            manifestConfig.baseUrl(),
-            manifestConfig.appId(),
-            manifestConfig.subscriptionKey()
+            baseUrl = manifestConfig.baseUrl(),
+            appId = manifestConfig.appId(),
+            subscriptionKey = manifestConfig.subscriptionKey(),
+            cacheDirectory = context.cacheDir
         )
         val cache = ConfigCache(context, fetcher)
 

--- a/remote-config/src/test/kotlin/com/rakuten/tech/mobile/remoteconfig/ConfigFetcherSpec.kt
+++ b/remote-config/src/test/kotlin/com/rakuten/tech/mobile/remoteconfig/ConfigFetcherSpec.kt
@@ -13,13 +13,16 @@ import org.amshove.kluent.shouldStartWith
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import org.robolectric.RuntimeEnvironment
+import java.io.File
 import java.io.IOException
 import java.util.logging.Level
 import java.util.logging.LogManager
 
-class ConfigFetcherSpec {
+class ConfigFetcherSpec : RobolectricBaseSpec() {
 
     private val server = MockWebServer()
+    private val context = RuntimeEnvironment.application
     private lateinit var baseUrl: String
 
     init {
@@ -91,6 +94,29 @@ class ConfigFetcherSpec {
         server.takeRequest().headers["apiKey"] shouldEqual "ras-test_subscription_key"
     }
 
+    @Test
+    fun `should return cached config for 304 response code`() {
+        val fetcher = createFetcher()
+        enqueueResponseValues(hashMapOf("foo" to "bar"))
+        server.enqueue(MockResponse().setResponseCode(304))
+
+        fetcher.fetch()
+
+        fetcher.fetch()["foo"] shouldEqual "bar"
+    }
+
+    @Test
+    fun `should cache the config between App launches`() {
+        enqueueResponseValues(hashMapOf("foo" to "bar"))
+        server.enqueue(MockResponse().setResponseCode(304))
+
+        createFetcher(cacheDirectory = context.cacheDir)
+            .fetch()
+
+        createFetcher(cacheDirectory = context.cacheDir)
+            .fetch()["foo"] shouldEqual "bar"
+    }
+
     @Test(expected = Exception::class)
     fun `should throw when an invalid base url is provided`() {
         enqueueResponseValues()
@@ -146,19 +172,27 @@ class ConfigFetcherSpec {
         values: Map<String, String> = hashMapOf("foo" to "bar")
     ) {
         server.enqueue(
-            MockResponse().setBody("""
+            MockResponse()
+                .setBody("""
                 {
                     "body": ${Json.nonstrict.stringify(
                         (StringSerializer to StringSerializer).map, values
                     )}
                 }
             """.trimIndent())
+                .setHeader("etag", "test")
         )
     }
 
     private fun createFetcher(
         url: String = baseUrl,
         appId: String = "test_app_id",
-        subscriptionKey: String = "test_subscription_key"
-    ) = ConfigFetcher(url, appId, subscriptionKey)
+        subscriptionKey: String = "test_subscription_key",
+        cacheDirectory: File = context.cacheDir
+    ) = ConfigFetcher(
+        baseUrl = url,
+        appId = appId,
+        subscriptionKey = subscriptionKey,
+        cacheDirectory = cacheDirectory
+    )
 }

--- a/remote-config/src/test/kotlin/com/rakuten/tech/mobile/remoteconfig/ConfigFetcherSpec.kt
+++ b/remote-config/src/test/kotlin/com/rakuten/tech/mobile/remoteconfig/ConfigFetcherSpec.kt
@@ -43,18 +43,16 @@ class ConfigFetcherSpec : RobolectricBaseSpec() {
 
     @Test
     fun `should fetch the config`() {
-        enqueueResponseValues(hashMapOf("foo" to "bar"))
-
         val fetcher = createFetcher()
+        enqueueResponseValues(hashMapOf("foo" to "bar"))
 
         fetcher.fetch()["foo"] shouldEqual "bar"
     }
 
     @Test
     fun `should fetch the config from the provided url`() {
-        enqueueResponseValues()
-
         val fetcher = createFetcher(url = baseUrl)
+        enqueueResponseValues()
 
         fetcher.fetch()
 
@@ -63,9 +61,8 @@ class ConfigFetcherSpec : RobolectricBaseSpec() {
 
     @Test
     fun `should fetch the config for the provided App Id`() {
-        enqueueResponseValues()
-
         val fetcher = createFetcher(appId = "test-app-id")
+        enqueueResponseValues()
 
         fetcher.fetch()
 
@@ -74,9 +71,8 @@ class ConfigFetcherSpec : RobolectricBaseSpec() {
 
     @Test
     fun `should fetch the config from the 'config' endpoint`() {
-        enqueueResponseValues()
-
         val fetcher = createFetcher()
+        enqueueResponseValues()
 
         fetcher.fetch()
 
@@ -85,9 +81,8 @@ class ConfigFetcherSpec : RobolectricBaseSpec() {
 
     @Test
     fun `should fetch the config using the provided Subscription Key prepended with 'ras-'`() {
-        enqueueResponseValues()
-
         val fetcher = createFetcher(subscriptionKey = "test_subscription_key")
+        enqueueResponseValues()
 
         fetcher.fetch()
 
@@ -119,29 +114,23 @@ class ConfigFetcherSpec : RobolectricBaseSpec() {
 
     @Test(expected = Exception::class)
     fun `should throw when an invalid base url is provided`() {
-        enqueueResponseValues()
-
         createFetcher(url = "invalid url")
     }
 
     @Test(expected = IOException::class)
     fun `should throw when the request is unsuccessful`() {
-        server.enqueue(
-            MockResponse().setResponseCode(400)
-        )
-
         val fetcher = createFetcher()
+        server.enqueue(MockResponse().setResponseCode(400))
 
         fetcher.fetch()
     }
 
     @Test(expected = Exception::class)
     fun `should throw when the 'body' key is missing in response`() {
+        val fetcher = createFetcher()
         server.enqueue(
             MockResponse().setBody("""{"randomKey":"random_value"}""")
         )
-
-        val fetcher = createFetcher()
 
         fetcher.fetch()
     }
@@ -149,6 +138,7 @@ class ConfigFetcherSpec : RobolectricBaseSpec() {
     @Test
     @Suppress("TooGenericExceptionCaught")
     fun `should not throw when there are extra keys in the response`() {
+        val fetcher = createFetcher()
         server.enqueue(
             MockResponse().setBody("""
                 {
@@ -157,8 +147,6 @@ class ConfigFetcherSpec : RobolectricBaseSpec() {
                 }
             """.trimIndent())
         )
-
-        val fetcher = createFetcher()
 
         try {
             fetcher.fetch()


### PR DESCRIPTION
# Description
Adds response cache to OkHttp. This will automatically handle caching based on preferences from the API, such as utilizing ETag and If-None-Match headers.

## Links
SDKCF-1095

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors