### PR TITLE
Encrypt public key before saving to cache

### DIFF
--- a/remote-config/build.gradle
+++ b/remote-config/build.gradle
@@ -26,7 +26,7 @@ dependencies {
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.1.1"
 
   testImplementation 'junit:junit:4.12'
-  testImplementation 'org.robolectric:robolectric:3.8'
+  testImplementation 'org.robolectric:robolectric:4.3'
   testImplementation "org.amshove.kluent:kluent-android:1.48"
   testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.1.0"
   testImplementation "org.mockito:mockito-inline:2.28.2"

--- a/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/verification/AesEncryptor.kt
+++ b/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/verification/AesEncryptor.kt
@@ -1,0 +1,113 @@
+package com.rakuten.tech.mobile.remoteconfig.verification
+
+import android.os.Build
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import android.util.Log
+import javax.crypto.Cipher
+import javax.crypto.spec.GCMParameterSpec
+import androidx.annotation.RequiresApi
+import androidx.annotation.VisibleForTesting
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import java.security.KeyStore
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+
+@RequiresApi(Build.VERSION_CODES.M)
+internal class AesEncryptor @VisibleForTesting constructor(
+    private val keyStore: KeyStore,
+    private val keyGenerator: AesKeyGenerator
+) : Encryptor {
+
+    constructor() : this(
+        keyStore = KeyStore.getInstance("AndroidKeyStore"),
+        keyGenerator = AesKeyGenerator(alias = KEYSTORE_ALIAS, provider = "AndroidKeyStore")
+    )
+
+    private val encryptionKey get() = (
+        try {
+            keyStore.getEntry(KEYSTORE_ALIAS, null) as KeyStore.SecretKeyEntry?
+        } catch (exception: ClassCastException) {
+            // Key wasn't an AES key, so we need to generate a new one
+            Log.d(
+                "Remote Config",
+                "Error retrieving key from KeyStore. A new key will be generated.",
+                exception
+            )
+            null
+        }
+    )?.secretKey ?: keyGenerator.generateKey()
+
+    init {
+        keyStore.load(null)
+    }
+
+    override fun encrypt(data: String): String {
+        val cipher = Cipher.getInstance(CIPHER_TRANSFORMATION)
+        cipher.init(Cipher.ENCRYPT_MODE, encryptionKey)
+        val encryptedData = cipher.doFinal(data.toByteArray(Charsets.UTF_8))
+
+        return AesEncryptedData(
+            Base64.encodeToString(cipher.iv, Base64.DEFAULT),
+            Base64.encodeToString(encryptedData, Base64.DEFAULT)
+        ).toJsonString()
+    }
+
+    override fun decrypt(data: String): String {
+        val (iv, encryptedData) = AesEncryptedData.fromJsonString(data)
+
+        val cipher = Cipher.getInstance(CIPHER_TRANSFORMATION)
+        val spec = GCMParameterSpec(GCM_TAG_LENGTH, Base64.decode(iv, Base64.DEFAULT))
+        cipher.init(Cipher.DECRYPT_MODE, encryptionKey, spec)
+
+        val decryptedData = cipher.doFinal(Base64.decode(encryptedData, Base64.DEFAULT))
+
+        return String(decryptedData)
+    }
+
+    companion object {
+        private const val KEYSTORE_ALIAS = "remote-config-public-key-encryption-decryption"
+        private const val CIPHER_TRANSFORMATION = "AES/GCM/NoPadding"
+        private const val GCM_TAG_LENGTH = 128
+    }
+}
+
+@RequiresApi(Build.VERSION_CODES.M)
+internal class AesKeyGenerator(
+    private val alias: String,
+    private val provider: String
+) {
+
+    fun generateKey(): SecretKey {
+        val algorithmSpec = KeyGenParameterSpec.Builder(alias, PURPOSE)
+            .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+            .setRandomizedEncryptionRequired(true)
+            .build()
+
+        val keyGenerator =
+            KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, provider)
+
+        keyGenerator.init(algorithmSpec)
+        return keyGenerator.generateKey()
+    }
+
+    companion object {
+        private const val PURPOSE = KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+    }
+}
+
+@Serializable
+private data class AesEncryptedData(
+    val iv: String,
+    val encryptedData: String
+) {
+
+    fun toJsonString() = Json.stringify(serializer(), this)
+
+    companion object {
+        fun fromJsonString(body: String) = Json.nonstrict.parse(serializer(), body)
+    }
+}

--- a/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/verification/ConfigVerifier.kt
+++ b/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/verification/ConfigVerifier.kt
@@ -16,18 +16,13 @@ internal class ConfigVerifier @VisibleForTesting constructor(
     fun verify(config: Config): Boolean {
         return try {
             val publicKey = cache[config.keyId] ?: return false
-
             val isVerified = signatureVerifier.verify(
                 publicKey,
                 config.values.toInputStream(),
                 config.signature
             )
 
-            if (isVerified) {
-                true
-            } else {
-                throw InvalidSignatureException()
-            }
+            if (isVerified) true else throw InvalidSignatureException()
         } catch (exception: Exception) {
             Log.e("Remote Config", "Failed to verify signature of config.", exception)
             cache.remove(config.keyId)

--- a/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/verification/Encryptor.kt
+++ b/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/verification/Encryptor.kt
@@ -1,0 +1,6 @@
+package com.rakuten.tech.mobile.remoteconfig.verification
+
+internal interface Encryptor {
+    fun encrypt(data: String): String
+    fun decrypt(data: String): String
+}

--- a/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/verification/RsaEncryptor.kt
+++ b/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/verification/RsaEncryptor.kt
@@ -1,0 +1,95 @@
+package com.rakuten.tech.mobile.remoteconfig.verification
+
+import android.content.Context
+import android.security.KeyPairGeneratorSpec
+import android.util.Base64
+import android.util.Log
+import androidx.annotation.VisibleForTesting
+import java.math.BigInteger
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.KeyStore
+import java.util.Calendar
+import javax.crypto.Cipher
+import javax.security.auth.x500.X500Principal
+
+internal class RsaEncryptor @VisibleForTesting constructor(
+    private val context: Context,
+    private val keyStore: KeyStore,
+    private val keyGenerator: RsaKeyGenerator
+) : Encryptor {
+
+    constructor(context: Context) : this(
+        context = context,
+        keyStore = KeyStore.getInstance("AndroidKeyStore"),
+        keyGenerator = RsaKeyGenerator(KEYSTORE_ALIAS)
+    )
+
+    private val encryptionKey get() = (
+        try {
+            keyStore.getEntry(KEYSTORE_ALIAS, null) as KeyStore.PrivateKeyEntry?
+        } catch (exception: ClassCastException) {
+            // Key wasn't an RSA key, so we need to generate a new one
+            Log.d(
+                "Remote Config",
+                "Error retrieving key from KeyStore. A new key will be generated.",
+                exception
+            )
+            null
+        }
+    )?.certificate?.publicKey ?: keyGenerator.generateKey(context).public
+
+    private val decryptionKey get() = (
+        keyStore.getEntry(KEYSTORE_ALIAS, null) as KeyStore.PrivateKeyEntry
+    ).privateKey
+
+    init {
+        keyStore.load(null)
+    }
+
+    override fun encrypt(data: String): String {
+        val cipher = Cipher.getInstance(CIPHER_TRANSFORMATION)
+        cipher.init(Cipher.ENCRYPT_MODE, encryptionKey)
+        val encryptedData = cipher.doFinal(data.toByteArray(Charsets.UTF_8))
+
+        return Base64.encodeToString(encryptedData, Base64.DEFAULT)
+    }
+
+    override fun decrypt(data: String): String {
+        val cipher = Cipher.getInstance(CIPHER_TRANSFORMATION)
+        cipher.init(Cipher.DECRYPT_MODE, decryptionKey)
+        val decryptedKey = cipher.doFinal(Base64.decode(data, Base64.DEFAULT))
+
+        return String(decryptedKey)
+    }
+
+    companion object {
+        private const val KEYSTORE_ALIAS = "remote-config-public-key-encryption-decryption"
+        private const val CIPHER_TRANSFORMATION = "RSA/ECB/PKCS1Padding"
+    }
+}
+
+internal class RsaKeyGenerator(
+    private val alias: String
+) {
+
+    fun generateKey(context: Context): KeyPair {
+        val start = Calendar.getInstance()
+        val end = Calendar.getInstance()
+        end.add(Calendar.YEAR, CERTIFICATE_DURATION_YEARS)
+        val spec = KeyPairGeneratorSpec.Builder(context)
+            .setAlias(alias)
+            .setSubject(X500Principal("CN=Rakuten Inc"))
+            .setSerialNumber(BigInteger.ONE)
+            .setStartDate(start.time)
+            .setEndDate(end.time)
+            .build()
+        val generator = KeyPairGenerator.getInstance("RSA", "AndroidKeyStore")
+        generator.initialize(spec)
+        return generator.generateKeyPair()
+    }
+
+    companion object {
+        private const val CERTIFICATE_DURATION_YEARS = 10
+    }
+}

--- a/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/verification/SignatureVerifier.kt
+++ b/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/verification/SignatureVerifier.kt
@@ -37,8 +37,7 @@ internal class SignatureVerifier {
 
         // First Byte represents compressed/uncompressed status
         // We're expecting it to always be uncompressed (04)
-        var offset =
-            UNCOMPRESSED_OFFSET
+        var offset = UNCOMPRESSED_OFFSET
         val x = BigInteger(POSITIVE_BIG_INTEGER, pubKey.copyOfRange(offset, offset + keySizeBytes))
 
         offset += keySizeBytes

--- a/remote-config/src/test/kotlin/com/rakuten/tech/mobile/remoteconfig/RobolectricBaseSpec.kt
+++ b/remote-config/src/test/kotlin/com/rakuten/tech/mobile/remoteconfig/RobolectricBaseSpec.kt
@@ -6,6 +6,6 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [27])
+@Config(sdk = [28])
 @Ignore
 open class RobolectricBaseSpec

--- a/remote-config/src/test/kotlin/com/rakuten/tech/mobile/remoteconfig/verification/AesEncryptorSpec.kt
+++ b/remote-config/src/test/kotlin/com/rakuten/tech/mobile/remoteconfig/verification/AesEncryptorSpec.kt
@@ -1,0 +1,83 @@
+package com.rakuten.tech.mobile.remoteconfig.verification
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.mock
+import com.rakuten.tech.mobile.remoteconfig.RobolectricBaseSpec
+import org.amshove.kluent.*
+import org.junit.Before
+import org.junit.Test
+import java.security.KeyStore
+
+class AesEncryptorSpec : RobolectricBaseSpec() {
+
+    private val mockKeyStore: KeyStore = mock()
+    private val mockKeyGenerator: AesKeyGenerator = mock()
+    private val mockKeyEntry: KeyStore.SecretKeyEntry = mock()
+
+    @Before
+    fun setup() {
+        val key = generateAesKey()
+        When calling mockKeyGenerator.generateKey() itReturns key
+        When calling mockKeyEntry.secretKey itReturns key
+        When calling mockKeyStore.getEntry(any(), anyOrNull()) itReturns mockKeyEntry
+    }
+
+    @Test
+    fun `it should encrypt the data`() {
+        val encryptor = createAesEncryptor()
+
+        encryptor.encrypt("test data") shouldNotContain "test data"
+    }
+
+    @Test
+    fun `it should attach IV`() {
+        val encryptor = createAesEncryptor()
+
+        encryptor.encrypt("test data") shouldContain "\"iv\":"
+    }
+
+    @Test
+    fun `it should decrypt the data`() {
+        val encryptor = createAesEncryptor()
+
+        val encryptedData = encryptor.encrypt("test data")
+
+        encryptor.decrypt(encryptedData) shouldEqual "test data"
+    }
+
+    @Test
+    fun `it should generate a new key when one is not in the key store`() {
+        When calling mockKeyStore.getEntry(any(), anyOrNull()) itReturns null
+        val encryptor = createAesEncryptor()
+
+        encryptor.encrypt("test data")
+
+        Verify on mockKeyGenerator that mockKeyGenerator.generateKey() was called
+    }
+
+    @Test
+    fun `it should not generate a key when one is already in the key store`() {
+        When calling mockKeyGenerator.generateKey() itReturns mock()
+        val encryptor = createAesEncryptor()
+
+        encryptor.encrypt("test data")
+
+        VerifyNotCalled on mockKeyGenerator that mockKeyGenerator.generateKey()
+    }
+
+    @Test
+    fun `it should generate a new key when the one in the store is not an AES key`() {
+        val mockRsaKeyEntry: KeyStore.PrivateKeyEntry = mock()
+        When calling mockKeyStore.getEntry(any(), anyOrNull()) itReturns mockRsaKeyEntry
+        val encryptor = createAesEncryptor()
+        encryptor.encrypt("test data")
+
+        Verify on mockKeyGenerator that mockKeyGenerator.generateKey() was called
+    }
+
+    private fun createAesEncryptor(
+        keyStore: KeyStore = mockKeyStore,
+        keyGenerator: AesKeyGenerator = mockKeyGenerator
+    ) = AesEncryptor(keyStore, keyGenerator)
+}

--- a/remote-config/src/test/kotlin/com/rakuten/tech/mobile/remoteconfig/verification/EncryptorTestUtils.kt
+++ b/remote-config/src/test/kotlin/com/rakuten/tech/mobile/remoteconfig/verification/EncryptorTestUtils.kt
@@ -1,0 +1,18 @@
+package com.rakuten.tech.mobile.remoteconfig.verification
+
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+
+internal fun generateAesKey(): SecretKey {
+    val kgen = KeyGenerator.getInstance("AES")
+    kgen.init(256)
+    return kgen.generateKey()
+}
+
+internal fun generateRsaKey(): KeyPair {
+    val generator = KeyPairGenerator.getInstance("RSA")
+    generator.initialize(512)
+    return generator.generateKeyPair()
+}

--- a/remote-config/src/test/kotlin/com/rakuten/tech/mobile/remoteconfig/verification/PublicKeyCacheSpec.kt
+++ b/remote-config/src/test/kotlin/com/rakuten/tech/mobile/remoteconfig/verification/PublicKeyCacheSpec.kt
@@ -1,6 +1,7 @@
 package com.rakuten.tech.mobile.remoteconfig.verification
 
 import android.content.Context
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.rakuten.tech.mobile.remoteconfig.RobolectricBaseSpec
 import com.rakuten.tech.mobile.remoteconfig.api.PublicKeyFetcher
@@ -15,10 +16,13 @@ import org.robolectric.RuntimeEnvironment
 class PublicKeyCacheSpec : RobolectricBaseSpec() {
 
     private val stubFetcher: PublicKeyFetcher = mock()
+    private val stubEncryptor: Encryptor = mock()
 
     @Before
     fun setup() {
         When calling stubFetcher.fetch("test_key_id") itReturns "test_public_key"
+        When calling stubEncryptor.encrypt("test_public_key") itReturns "test_public_key"
+        When calling stubEncryptor.decrypt("test_public_key") itReturns "test_public_key"
     }
 
     @Test
@@ -51,8 +55,20 @@ class PublicKeyCacheSpec : RobolectricBaseSpec() {
         cache["test_key_id"] shouldEqual "test_public_key"
     }
 
+    @Test
+    fun `should cache the public key in an encrypted form after fetching`() {
+        When calling stubEncryptor.encrypt(any()) itReturns "encrypted_publicKey"
+        When calling stubEncryptor.decrypt("encrypted_publicKey") itReturns "decrypted_public_key"
+        val cache = createCache()
+
+        cache.fetch("test_key_id")
+
+        cache["test_key_id"] shouldEqual "decrypted_public_key"
+    }
+
     private fun createCache(
         fetcher: PublicKeyFetcher = stubFetcher,
-        context: Context = RuntimeEnvironment.application
-    ) = PublicKeyCache(fetcher, context)
+        context: Context = RuntimeEnvironment.application,
+        encryptor: Encryptor = stubEncryptor
+    ) = PublicKeyCache(fetcher, context, encryptor)
 }

--- a/remote-config/src/test/kotlin/com/rakuten/tech/mobile/remoteconfig/verification/RsaEncryptorSpec.kt
+++ b/remote-config/src/test/kotlin/com/rakuten/tech/mobile/remoteconfig/verification/RsaEncryptorSpec.kt
@@ -1,0 +1,82 @@
+package com.rakuten.tech.mobile.remoteconfig.verification
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.mock
+import com.rakuten.tech.mobile.remoteconfig.RobolectricBaseSpec
+import org.amshove.kluent.*
+import org.junit.Before
+import org.junit.Test
+import java.security.KeyStore
+import java.security.cert.Certificate
+
+class RsaEncryptorSpec : RobolectricBaseSpec() {
+
+    private val mockKeyStore: KeyStore = mock()
+    private val mockKeyGenerator: RsaKeyGenerator = mock()
+    private val mockKeyEntry: KeyStore.PrivateKeyEntry = mock()
+
+    @Before
+    fun setup() {
+        val key = generateRsaKey()
+        val certificate: Certificate = mock()
+        When calling certificate.publicKey itReturns key.public
+        When calling mockKeyStore.getEntry(any(), anyOrNull()) itReturns mockKeyEntry
+        When calling mockKeyEntry.privateKey itReturns key.private
+        When calling mockKeyEntry.certificate itReturns certificate
+        When calling mockKeyGenerator.generateKey(any()) itReturns key
+    }
+
+    @Test
+    fun `it should encrypt the data`() {
+        val encryptor = createRsaEncryptor()
+
+        encryptor.encrypt("test data") shouldNotContain "test data"
+    }
+
+    @Test
+    fun `it should decrypt the data`() {
+        val encryptor = createRsaEncryptor()
+
+        val encryptedData = encryptor.encrypt("test data")
+
+        encryptor.decrypt(encryptedData) shouldEqual "test data"
+    }
+
+    @Test
+    fun `it should generate a new key when one isn't in the key store`() {
+        When calling mockKeyStore.getEntry(any(), anyOrNull()) itReturns null
+        val encryptor = createRsaEncryptor()
+
+        encryptor.encrypt("test data")
+
+        Verify on mockKeyGenerator that mockKeyGenerator.generateKey(any()) was called
+    }
+
+    @Test
+    fun `it should not generate a key when one is already in the key store`() {
+        When calling mockKeyGenerator.generateKey(any()) itReturns mock()
+        val encryptor = createRsaEncryptor()
+
+        val encryptedData = encryptor.encrypt("test data")
+        encryptor.decrypt(encryptedData)
+
+        VerifyNotCalled on mockKeyGenerator that mockKeyGenerator.generateKey(any())
+    }
+
+    @Test
+    fun `it should generate a new key when the one in the store is not an AES key`() {
+        val mockAesKeyEntry: KeyStore.SecretKeyEntry = mock()
+        When calling mockKeyStore.getEntry(any(), anyOrNull()) itReturns mockAesKeyEntry
+        val encryptor = createRsaEncryptor()
+
+        encryptor.encrypt("test data")
+
+        Verify on mockKeyGenerator that mockKeyGenerator.generateKey(any()) was called
+    }
+
+    private fun createRsaEncryptor(
+        keyStore: KeyStore = mockKeyStore,
+        keyGenerator: RsaKeyGenerator = mockKeyGenerator
+    ) = RsaEncryptor(mock(), keyStore, keyGenerator)
+}


### PR DESCRIPTION
# Description
This will prevent the cached public key from being modified on a rooted device

## Links
SDKCF-1094

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors