### PR TITLE
fix: Trim the fetched config response

### DIFF
--- a/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/api/ConfigFetcher.kt
+++ b/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/api/ConfigFetcher.kt
@@ -19,6 +19,7 @@ internal class ConfigFetcher constructor(
         }
 
         val body = response.body()!!.string()
+            .trim() // OkHttp sometimes adds an extra newline character when caching the response
         val (_body, keyId) = ConfigResponse.fromJsonString(body)
         val signature = response.header("Signature") ?: ""
 


### PR DESCRIPTION
# Description
Sometimes OkHttp caches the response with an extra new line at the end. This fix will ensure that the cached response can still pass signature verifcation.

## Links
[SDKCF-1449]

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors