### PR TITLE
fix: Crash on some devices on initial launch

### DIFF
--- a/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/ConfigCache.kt
+++ b/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/ConfigCache.kt
@@ -34,10 +34,10 @@ internal class ConfigCache @VisibleForTesting constructor(
     )
 
     private val configBody = if (file.exists()) {
-        val config = Config.fromJsonString(file.readText())
+        val text = file.readText()
 
-        if (verifier.verify(config)) {
-            ConfigResponse.fromJsonString(config.rawBody).body
+        if (text.isNotBlank()) {
+            parseConfigBody(text) ?: emptyMap()
         } else {
             emptyMap()
         }
@@ -64,6 +64,19 @@ internal class ConfigCache @VisibleForTesting constructor(
     operator fun get(key: String) = configBody[key]
 
     fun getConfig(): Map<String, String> = configBody
+
+    private fun parseConfigBody(fileText: String) = try {
+        val config = Config.fromJsonString(fileText)
+
+        if (verifier.verify(config)) {
+            ConfigResponse.fromJsonString(config.rawBody).body
+        } else {
+            null
+        }
+    } catch (exception: Exception) {
+        Log.e("RemoteConfig", "Error parsing config from cached file", exception)
+        null
+    }
 }
 
 @Serializable


### PR DESCRIPTION
# Description
In some circumstances on some devices,  was returning true even though the file had not been created yet. I have added extra checks to ensure that it doesn't crash if the file is empty or invalid

## Links
SDKCF-1450

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors