### PR TITLE
fix: Use no_backup directory for caching

### DIFF
--- a/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/ConfigCache.kt
+++ b/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/ConfigCache.kt
@@ -26,7 +26,7 @@ internal class ConfigCache @VisibleForTesting constructor(
     ) : this(
         configFetcher,
         File(
-            context.filesDir,
+            context.noBackupFilesDir,
             "com.rakuten.tech.mobile.remoteconfig.configcache.json"
         ),
         poller,

--- a/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/verification/PublicKeyCache.kt
+++ b/remote-config/src/main/kotlin/com/rakuten/tech/mobile/remoteconfig/verification/PublicKeyCache.kt
@@ -4,6 +4,10 @@ import android.content.Context
 import android.os.Build
 import androidx.annotation.VisibleForTesting
 import com.rakuten.tech.mobile.remoteconfig.api.PublicKeyFetcher
+import kotlinx.serialization.internal.StringSerializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.map
+import java.io.File
 
 internal class PublicKeyCache @VisibleForTesting constructor(
     private val keyFetcher: PublicKeyFetcher,
@@ -23,34 +27,54 @@ internal class PublicKeyCache @VisibleForTesting constructor(
             RsaEncryptor(context)
     )
 
-    private val prefs = context.getSharedPreferences(
-        "com.rakuten.tech.mobile.remoteconfig.publickeys",
-        Context.MODE_PRIVATE
+    private val file = File(
+        context.noBackupFilesDir,
+        "com.rakuten.tech.mobile.remoteconfig.publickeys.json"
     )
+    private val keys = if (file.exists()) {
+        val text = file.readText()
+
+        if (text.isNotBlank()) {
+            parseJson(text).toMutableMap()
+        } else {
+            mutableMapOf()
+        }
+    } else {
+        mutableMapOf()
+    }
 
     operator fun get(keyId: String): String? {
-        val encryptedKey = prefs.getString(keyId, null)
+        val encryptedKey = keys[keyId]
             ?: return null
 
         return encryptor.decrypt(encryptedKey)
     }
 
     fun remove(keyId: String) {
-        prefs.edit()
-            .remove(keyId)
-            .apply()
+        keys.remove(keyId)
+
+        file.writeText(keys.toJsonString())
     }
 
     fun fetch(keyId: String): String {
         val key = keyFetcher.fetch(keyId)
 
-        // Key is encrypted to prevent modification in SharedPreferences (i.e. on a rooted device)
+        // Key is encrypted to prevent modification of the cached file (i.e. on a rooted device)
         val encryptedKey = encryptor.encrypt(key)
+        keys[keyId] = encryptedKey
 
-        prefs.edit()
-            .putString(keyId, encryptedKey)
-            .apply()
+        file.writeText(keys.toJsonString())
 
         return key
     }
+
+    private fun parseJson(json: String) = Json.nonstrict.parse(
+        (StringSerializer to StringSerializer).map,
+        json
+    )
+
+    private fun Map<String, String>.toJsonString() = Json.nonstrict.stringify(
+        (StringSerializer to StringSerializer).map,
+        this
+    )
 }


### PR DESCRIPTION
# Description
If an App has allowBackup=true and the user has backup enabled for their device, then the shared preferences and files directory will get backed up in the cloud. The saved files then get applied if they reinstall the app or install it on a new device. This causes problems because the public key is encrypted using a private key which is generated by the App. Also, this might be considered unexpected behavior by App developers and could be a security concern because data is being stored in a place that they did not intend. So I have changed the ConfigCache and the PublicKeyCache to use the no_backup directory which doesn't get saved when the device is backed up.

## Links
/SDKCF-1450

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors