### PR TITLE
fix: Initialize SDK Utils before Remote Config

### DIFF
--- a/remote-config/src/main/AndroidManifest.xml
+++ b/remote-config/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest
-  package="com.rakuten.tech.mobile.remoteconfig"
-  xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest package="com.rakuten.tech.mobile.remoteconfig"
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools">
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
@@ -11,5 +11,13 @@
       android:authorities="${applicationId}.RemoteConfigInitProvider"
       android:exported="false"
       android:initOrder="99" />
+
+    <!-- SDK Utils must be intiailzed before Remote Config -->
+    <provider
+      tools:replace="android:initOrder"
+      android:name="com.rakuten.tech.mobile.sdkutils.SdkUtilsInitProvider"
+      android:authorities="${applicationId}.SdkUtilsInitProvider"
+      android:exported="false"
+      android:initOrder="100" />
   </application>
 </manifest>


### PR DESCRIPTION
# Description
The initialization ContentProvider for each was previously set to the same value. This causes a race condition where sometimes SDK Utils has not initialized yet when it is needed by Remote Config

## Links

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors