### PR TITLE
ci: update ci environment to prevent OOM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,10 @@ jobs:
     - image: circleci/android:api-28
     working_directory: ~/code
     environment:
-      JVM_OPTS: "-Xmx3200m"
+      # from https://discuss.circleci.com/t/circle-ci-v2-and-android-memory-issues/11207
+      JVM_OPTS: "-Xmx1024m -XX:+PrintFlagsFinal -XX:+PrintGCDetails"
+      _JAVA_OPTIONS: "-Xmx1024m"
+      GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=1 -Dorg.gradle.parallel=false"
     steps:
     - checkout
     - run: git submodule update --init


### PR DESCRIPTION
* updated JVM, JAVA, and Gradle options to prevent out-of-memory issues encountered in other repo

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors